### PR TITLE
Add: directory experience for key with forward slash

### DIFF
--- a/obs/libs/bucket.py
+++ b/obs/libs/bucket.py
@@ -48,13 +48,15 @@ def remove_bucket(resource, bucket_name):
     resource.Bucket(bucket_name).delete()
 
 
-def get_objects(resource, bucket_name, prefix=""):
+def get_objects(resource, bucket_name, prefix=None):
     """List objects inside a bucket"""
-    objects = []
-    bucket = resource.Bucket(bucket_name)
-    for obj in bucket.objects.filter(Prefix=prefix):
-        objects.append(obj)
-    return objects
+    client = resource.meta.client
+    response = client.list_objects(Bucket=bucket_name, Prefix=prefix, Delimiter="/")
+
+    return {
+        "Contents": response.get("Contents"),
+        "CommonPrefixes": response.get("CommonPrefixes"),
+    }
 
 
 def is_exists(resource, bucket_name, object_name):

--- a/obs/storage/bucket.py
+++ b/obs/storage/bucket.py
@@ -38,14 +38,24 @@ def remove_bucket(resource, bucket_name):
 
 def get_objects(resource, bucket_name, prefix):
     try:
-        objects = bucket_lib.get_objects(resource, bucket_name, prefix)
-        if len(objects) > 0:
-            for obj in objects:
-                key = obj.key
-                size = utils.sizeof_fmt(obj.size)
-                click.secho(f"{obj.last_modified:%Y-%m-%d %H:%M:%S}, {size}, {key}")
-        else:
+        response = bucket_lib.get_objects(resource, bucket_name, prefix)
+        if not response:
             click.secho(f'Bucket "{bucket_name}" is empty', fg="green")
+
+        if response["CommonPrefixes"]:
+            for prefix in response["CommonPrefixes"]:
+                dir_ = "DIR".rjust(12)
+                click.secho(f"{dir_} {bucket_name}/{prefix['Prefix']}")
+
+        if response["Contents"]:
+            for content in response["Contents"]:
+                key = content["Key"]
+                size = utils.sizeof_fmt(content["Size"])
+                last_modified = content["LastModified"]
+                click.secho(
+                    f"{last_modified:%Y-%m-%d %H:%M:%S}, {size}, {bucket_name}/{key}"
+                )
+
     except Exception as exc:
         click.secho(f"{exc}", fg="yellow", bold=True, err=True)
 


### PR DESCRIPTION
Add directory experience for key with forward slash.

``` bash
user at machine in ~/test-dir <neo-obs>
$ obs storage ls aweseme-bucket
         DIR aweseme-bucket/a/
         DIR aweseme-bucket/a1/

user at machine in ~/test-dir <neo-obs>
$ obs storage ls aweseme-bucket -p a/
         DIR aweseme-bucket/a/b/

user at machine in ~/test-dir <neo-obs>
$ obs storage ls aweseme-bucket -p a/b/c/
2019-12-27 19:10:36, 8.0 B, aweseme-bucket/a/b/c/foo.txt
```